### PR TITLE
Optimisation: flatten changesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,3 @@ a look in the `env.js` file for a list of the available prefixes.
 ## TODO
 
 * Only allow deletes from graphs touchable by vendors.
-* Optimisations:
-  - Changesets can only include inserts or deletes (never both, due to separate
-    API paths)? This would mean we could flatten those lists and reduce the
-    amount of unique subjects between changesets → less queries and less
-    redundant work.

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.post('/delta-inserts', async function (req, res, next) {
   try {
     await lock.acquire();
     const changesets = req.body;
-    const result = await del.processDeltaChangesetsInserts(changesets);
+    const result = await del.processDeltaChangesets(changesets);
     handleProcessingResult(result);
   } catch (err) {
     next(err);
@@ -93,7 +93,7 @@ app.post('/delta-deletes', async function (req, res, next) {
       changeset.deletes = changeset.deletes.concat(changeset.inserts);
       changeset.inserts = [];
     }
-    const result = await del.processDeltaChangesetsDeletes(changesets);
+    const result = await del.processDeltaChangesets(changesets);
     handleProcessingResult(result);
   } catch (err) {
     next(err);

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.post('/delta-inserts', async function (req, res, next) {
   try {
     await lock.acquire();
     const changesets = req.body;
-    const result = await del.processDeltaChangesets(changesets);
+    const result = await del.processDeltaChangesetsInserts(changesets);
     handleProcessingResult(result);
   } catch (err) {
     next(err);
@@ -93,7 +93,7 @@ app.post('/delta-deletes', async function (req, res, next) {
       changeset.deletes = changeset.deletes.concat(changeset.inserts);
       changeset.inserts = [];
     }
-    const result = await del.processDeltaChangesets(changesets);
+    const result = await del.processDeltaChangesetsDeletes(changesets);
     handleProcessingResult(result);
   } catch (err) {
     next(err);

--- a/lib/deltaProcessing.js
+++ b/lib/deltaProcessing.js
@@ -72,7 +72,7 @@ async function processInserts(inserts) {
   if (store.size < 1)
     return {
       success: false,
-      type: 'Insert',
+      mode: 'Insert',
       reason: 'Nothing in the inserts to process.',
     };
 

--- a/lib/deltaProcessing.js
+++ b/lib/deltaProcessing.js
@@ -25,10 +25,11 @@ import pta from '../config/pathsToAdministrativeUnit';
  * @throws Will rethrow an exception if any error has occured (network, SPARQL,
  * timeout, ...)
  */
-async function processDeltaChangesets(changesets) {
+export async function processDeltaChangesets(changesets) {
+  const flattenedChangesets = flattenChangesets(changesets);
   let deletesResults = [];
   let insertsResults = [];
-  for (const changeset of changesets) {
+  for (const changeset of flattenedChangesets) {
     const deleteRes = await processDeletes(changeset.deletes);
     const insertRes = await processInserts(changeset.inserts);
     deletesResults = deletesResults.concat(deleteRes);
@@ -38,64 +39,6 @@ async function processDeltaChangesets(changesets) {
     inserts: insertsResults,
     deletes: deletesResults,
   };
-}
-
-/**
- * Main entry function for processing deltas about inserts. Stores inserts in
- * the correct organisation graph (configurable via query paths). Use this over
- * the more generic `processDeltaChangesets` because this function optimises
- * inserts by bundeling them in the same changeset if there are no deletes.
- *
- * @async
- * @function
- * @param {Iterable} changesets - This is an iterable collection of changesets
- * from the delta-notifier, usually an Array with objects like `{ inserts:
- * [...], deletes: [...] }`
- * @returns {Object} An object with properties `inserts` and `deletes` that
- * contain the results from `processInserts` and `processDeletes` respectively.
- * @throws Will rethrow an exception if any error has occured (network, SPARQL,
- * timeout, ...)
- */
-export async function processDeltaChangesetsInserts(changesets) {
-  if (changesets.some((set) => set.deletes.length > 0)) {
-    return processDeltaChangesets(changesets);
-  } else {
-    const inserts = changesets.map((set) => set.inserts).flat();
-    const insertsResults = await processInserts(inserts);
-    return {
-      inserts: insertsResults,
-      deletes: [],
-    };
-  }
-}
-
-/**
- * Main entry function for processing deltas about deletes. Performs deletes in
- * the temporary data and the organisation graph. Use this over the more
- * generic `processDeltaChangesets` because this function optimises deletes by
- * bundeling them in the same changeset if there are no inserts.
- *
- * @async
- * @function
- * @param {Iterable} changesets - This is an iterable collection of changesets
- * from the delta-notifier, usually an Array with objects like `{ inserts:
- * [...], deletes: [...] }`
- * @returns {Object} An object with properties `inserts` and `deletes` that
- * contain the results from `processInserts` and `processDeletes` respectively.
- * @throws Will rethrow an exception if any error has occured (network, SPARQL,
- * timeout, ...)
- */
-export async function processDeltaChangesetsDeletes(changesets) {
-  if (changesets.some((set) => set.inserts.length > 0)) {
-    return processDeltaChangesets(changesets);
-  } else {
-    const deletes = changesets.map((set) => set.deletes).flat();
-    const deletesResults = await processDeletes(deletes);
-    return {
-      inserts: [],
-      deletes: deletesResults,
-    };
-  }
 }
 
 /**
@@ -573,4 +516,43 @@ async function moveSubjectBetweenGraphs(subject, originalGraph, targetGraph) {
     deleteStore.addQuad(triple);
     await sts.deleteData(deleteStore, originalGraph);
   }
+}
+
+/**
+ * Transforms a collection of changesets with inserts and deletes into a
+ * collection of bundled inserts and deletes, making sure not to mix the
+ * ordering between deletes and inserts. Ordering between inserts and between
+ * deletes is not maintained. This is still OK for processing in order.
+ *
+ * @function
+ * @param {Iterable} changesets - A regular collection of changesets.
+ * @returns {Array(Object)} Very similar to the changesets argument. This is an
+ * array of objects with only inserts or only deletes.
+ */
+function flattenChangesets(changesets) {
+  const flattens = [];
+  for (const changeset of changesets) {
+    const latest = flattens[flattens.length - 1];
+    if (changeset.deletes.length > 0) {
+      if (!latest || latest.deletes.length <= 0) {
+        flattens.push({
+          inserts: [],
+          deletes: changeset.deletes,
+        });
+      } else if (latest.deletes.length > 0) {
+        latest.deletes = latest.deletes.concat(changeset.deletes);
+      }
+    }
+    if (changeset.inserts.length > 0) {
+      if (!latest || latest.inserts.length <= 0) {
+        flattens.push({
+          inserts: changeset.inserts,
+          deletes: [],
+        });
+      } else if (latest.inserts.length > 0) {
+        latest.inserts = latest.inserts.concat(changeset.inserts);
+      }
+    }
+  }
+  return flattens;
 }

--- a/lib/deltaProcessing.js
+++ b/lib/deltaProcessing.js
@@ -15,7 +15,6 @@ import pta from '../config/pathsToAdministrativeUnit';
  * the temporary data and the organisation graph. It processes deletions of
  * data before insertions of data per changeset in the order they appear.
  *
- * @public
  * @async
  * @function
  * @param {Iterable} changesets - This is an iterable collection of changesets
@@ -26,7 +25,7 @@ import pta from '../config/pathsToAdministrativeUnit';
  * @throws Will rethrow an exception if any error has occured (network, SPARQL,
  * timeout, ...)
  */
-export async function processDeltaChangesets(changesets) {
+async function processDeltaChangesets(changesets) {
   let deletesResults = [];
   let insertsResults = [];
   for (const changeset of changesets) {
@@ -39,6 +38,64 @@ export async function processDeltaChangesets(changesets) {
     inserts: insertsResults,
     deletes: deletesResults,
   };
+}
+
+/**
+ * Main entry function for processing deltas about inserts. Stores inserts in
+ * the correct organisation graph (configurable via query paths). Use this over
+ * the more generic `processDeltaChangesets` because this function optimises
+ * inserts by bundeling them in the same changeset if there are no deletes.
+ *
+ * @async
+ * @function
+ * @param {Iterable} changesets - This is an iterable collection of changesets
+ * from the delta-notifier, usually an Array with objects like `{ inserts:
+ * [...], deletes: [...] }`
+ * @returns {Object} An object with properties `inserts` and `deletes` that
+ * contain the results from `processInserts` and `processDeletes` respectively.
+ * @throws Will rethrow an exception if any error has occured (network, SPARQL,
+ * timeout, ...)
+ */
+export async function processDeltaChangesetsInserts(changesets) {
+  if (changesets.some((set) => set.deletes.length > 0)) {
+    return processDeltaChangesets(changesets);
+  } else {
+    const inserts = changesets.map((set) => set.inserts).flat();
+    const insertsResults = await processInserts(inserts);
+    return {
+      inserts: insertsResults,
+      deletes: [],
+    };
+  }
+}
+
+/**
+ * Main entry function for processing deltas about deletes. Performs deletes in
+ * the temporary data and the organisation graph. Use this over the more
+ * generic `processDeltaChangesets` because this function optimises deletes by
+ * bundeling them in the same changeset if there are no inserts.
+ *
+ * @async
+ * @function
+ * @param {Iterable} changesets - This is an iterable collection of changesets
+ * from the delta-notifier, usually an Array with objects like `{ inserts:
+ * [...], deletes: [...] }`
+ * @returns {Object} An object with properties `inserts` and `deletes` that
+ * contain the results from `processInserts` and `processDeletes` respectively.
+ * @throws Will rethrow an exception if any error has occured (network, SPARQL,
+ * timeout, ...)
+ */
+export async function processDeltaChangesetsDeletes(changesets) {
+  if (changesets.some((set) => set.inserts.length > 0)) {
+    return processDeltaChangesets(changesets);
+  } else {
+    const deletes = changesets.map((set) => set.deletes).flat();
+    const deletesResults = await processDeletes(deletes);
+    return {
+      inserts: [],
+      deletes: deletesResults,
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
A collection of changesets can be flattened. This means that inserts can be concatenated from multiple consecutive changesets if there is no delete in between. Deletes can also be concatenated in a similar way.

We only really need the unique subjects from every changeset to move data. Because inserts and deletes are only dealt with in their specific order, and changesets can be arbitrarily small, there was a lot of duplicated work because data about the same subject could appear in many different changesets. With flattening, data about the same subject could appear in less overall changesets and thus the same subject would be retried fewer times.