### PR TITLE
Batches for deletes and better fetching of graphs

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import * as env from './env';
 import * as mas from '@lblod/mu-auth-sudo';
 import * as rst from 'rdf-string-ttl';
 import * as del from './lib/deltaProcessing';
+import * as sts from './lib/storeToTriplestore';
 import { Lock } from 'async-await-mutex-lock';
 import * as N3 from 'n3';
 const { namedNode, literal } = N3.DataFactory;
@@ -217,7 +218,7 @@ function handleProcessingResult(results) {
           res.organisationGraphs = res.organisationGraphs.map((g) => g.value);
         if (res.organisationUUIDs)
           res.organisationUUIDs = res.organisationUUIDs.join(',');
-        if (res.triple) res.triple = del.formatTriple(res.triple);
+        if (res.triple) res.triple = sts.formatTriple(res.triple);
         if (res.graphs) res.graphs = res.graphs.join(',');
         console.log(res);
       }

--- a/env.js
+++ b/env.js
@@ -15,6 +15,8 @@ export const ORGANISATION_GRAPH_PREFIX = envvar
   .default('http://mu.semte.ch/graphs/organizations/')
   .asUrlString();
 
+export const BATCH_SIZE = envvar.get('BATCH_SIZE').default('100').asInt();
+
 export const LOGLEVEL = envvar
   .get('LOGLEVEL')
   .default('silent')

--- a/lib/deltaProcessing.js
+++ b/lib/deltaProcessing.js
@@ -251,6 +251,9 @@ async function processDeletes(deletes) {
  * @function
  * @param {N3.Store} store - Store containing the triples to be deleted. This
  * could be the contents of the temporary deletes graph.
+ * @param {Boolean} [doGraphSearch = true] Set whether or not we still have to
+ * search for all the graphs the triples appear in. If false, we can assume the
+ * different graphs for the triples are already present in the data.
  * @returns {Array(Object)} An array of objects, only for failed deletes.
  * Failures will be rare, but successes will be plenty so we don't want all
  * those logs. These objects have properties `success` (Boolean),  `mode`
@@ -422,7 +425,7 @@ async function getGraphsForTriples(store) {
       );
   });
   const response = await mas.querySudo(`
-    SELECT  DISTINCT ?s ?p ?o ?g WHERE {
+    SELECT DISTINCT ?s ?p ?o ?g WHERE {
       VALUES (?s ?p ?o) {
         ${values.join('\n')}
       }

--- a/lib/deltaProcessing.js
+++ b/lib/deltaProcessing.js
@@ -257,10 +257,15 @@ async function processDeletes(deletes) {
  * (String), `reason` (String), `triple` (Quad), and `graph` (NamedNode).
  * @throws Will throw an exception on any kind of error.
  */
-async function deleteTriples(store) {
+async function deleteTriples(store, doGraphSearch = true) {
   const results = [];
-  //Query for every triple all the graphs it exists in
-  const storeWithAllGraphs = await getGraphsForTriples(store);
+  let storeWithAllGraphs;
+  if (doGraphSearch) {
+    //Query for every triple all the graphs it exists in
+    storeWithAllGraphs = await getGraphsForTriples(store);
+  } else {
+    storeWithAllGraphs = store;
+  }
   const problematicTriples = [];
   for (const triple of store) {
     const graphs = storeWithAllGraphs
@@ -319,8 +324,10 @@ export async function scanAndProcess(processDeletes = true) {
   let deletesResults = [];
   if (processDeletes) {
     //Deletes
-    const deletes = await sts.getData(namedNode(env.TEMP_GRAPH_DELETES));
-    deletesResults = await deleteTriples(deletes);
+    const deletes = await sts.getTriplesAndAllGraphs(
+      namedNode(env.TEMP_GRAPH_DELETES)
+    );
+    deletesResults = await deleteTriples(deletes, false);
   }
 
   //Inserts

--- a/lib/storeToTriplestore.js
+++ b/lib/storeToTriplestore.js
@@ -125,6 +125,29 @@ export async function getData(graph) {
   return store;
 }
 
+export async function getTriplesAndAllGraphs(graph) {
+  if (!graph)
+    throw new Error(
+      'Querying without graph is probably a mistake as it will cause an explosion of data and is therefore not allowed.'
+    );
+  const response = await mas.querySudo(`
+    SELECT ?s ?p ?o ?g WHERE {
+      GRAPH ${rst.termToString(graph)} {
+        ?s ?p ?o .
+      }
+      GRAPH ?g {
+        ?s ?p ?o .
+      }
+    }`);
+  const parser = new sjp.SparqlJsonParser();
+  const parsedResults = parser.parseJsonResults(response);
+  const resultStore = new N3.Store();
+  parsedResults.forEach((res) => {
+    resultStore.addQuad(res.s, res.p, res.o, res.g);
+  });
+  return resultStore;
+}
+
 /**
  * Inserts the data from a store into the graphs defined in the data or in the
  * given graph.

--- a/lib/storeToTriplestore.js
+++ b/lib/storeToTriplestore.js
@@ -11,6 +11,7 @@ import * as rst from 'rdf-string-ttl';
 import * as sjp from 'sparqljson-parse';
 import * as mas from '@lblod/mu-auth-sudo';
 import * as N3 from 'n3';
+import * as env from '../env';
 import { NAMESPACES as ns } from '../env';
 
 /**
@@ -206,48 +207,31 @@ export async function insertData(store, graph) {
  */
 export async function deleteData(store, graph) {
   const deleteFunction = async (store, graph) => {
-    //Use a proper writer for when the data is properly formatted.
-    const writer = new N3.Writer();
-    store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
-    const triplesSparql1 = await new Promise((resolve, reject) =>
-      writer.end((error, result) => {
-        if (error) reject(error);
-        else resolve(result);
-      })
-    );
-    await mas.updateSudo(
-      `DELETE DATA {
-        GRAPH ${rst.termToString(graph)} {
-          ${triplesSparql1}
+    const triples = [...store];
+    let batchSize = env.BATCH_SIZE;
+    const originalBatchSize = env.BATCH_SIZE;
+    let start = 0;
+    while (start < triples.length) {
+      try {
+        const batch = triples.slice(start, start + batchSize);
+        await deleteTriplesFromGraphWithoutBatching(graph, batch);
+        start += batchSize;
+        batchSize = originalBatchSize;
+      } catch (err) {
+        if (batchSize > 1) {
+          batchSize = Math.ceil(batchSize / 2);
+        } else {
+          const tripleString = [
+            rst.termToString(triples[start].subject),
+            rst.termToString(triples[start].predicate),
+            rst.termToString(triples[start].object),
+          ].join(' ');
+          throw new Error(
+            `The following triple could not be removed from the triplestore:\n\t${tripleString}\nThis might be because of a network issue, a syntax issue or because the triple is too long.`
+          );
         }
-      }`,
-      {
-        'mu-call-scope-id': 'http://worship-positions-graph-dispatcher/update',
       }
-    );
-
-    //Also use a self made writer to format the triples in a special way for
-    //Virtuoso. Only do this when dealing with explicit string typed terms. Do
-    //this in a separate query to deal with another Virtuoso bug.
-    //Slightly less reliable and more verbose, but keeping the datatype is
-    //necessary for Virtuoso to be able to delete the data. Another bug?
-    const triplesSparql = [];
-    store.forEach((quad) => {
-      if (quad.object?.datatype?.value === ns.xsd`string`.value)
-        triplesSparql.push(formatTriple(quad));
-    });
-    if (triplesSparql.length)
-      await mas.updateSudo(
-        `DELETE DATA {
-          GRAPH ${rst.termToString(graph)} {
-            ${triplesSparql.join('\n')}
-          }
-        }`,
-        {
-          'mu-call-scope-id':
-            'http://worship-positions-graph-dispatcher/update',
-        }
-      );
+    }
   };
 
   if (store.size < 1) return;
@@ -257,4 +241,50 @@ export async function deleteData(store, graph) {
       const triples = store.getQuads(undefined, undefined, undefined, graph);
       await deleteFunction(triples, graph);
     }
+}
+
+async function deleteTriplesFromGraphWithoutBatching(graph, store) {
+  if (store.size && store.size <= 0) return;
+  if (store.length && store.length <= 0) return;
+  //Use a proper writer for when the data is properly formatted.
+  const writer = new N3.Writer();
+  store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
+  const triplesSparql1 = await new Promise((resolve, reject) =>
+    writer.end((error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    })
+  );
+  await mas.updateSudo(
+    `DELETE DATA {
+      GRAPH ${rst.termToString(graph)} {
+        ${triplesSparql1}
+      }
+    }`,
+    {
+      'mu-call-scope-id': 'http://worship-positions-graph-dispatcher/update',
+    }
+  );
+
+  //Also use a self made writer to format the triples in a special way for
+  //Virtuoso. Only do this when dealing with explicit string typed terms. Do
+  //this in a separate query to deal with another Virtuoso bug.
+  //Slightly less reliable and more verbose, but keeping the datatype is
+  //necessary for Virtuoso to be able to delete the data. Another bug?
+  const triplesSparql = [];
+  store.forEach((quad) => {
+    if (quad.object?.datatype?.value === ns.xsd`string`.value)
+      triplesSparql.push(formatTriple(quad));
+  });
+  if (triplesSparql.length)
+    await mas.updateSudo(
+      `DELETE DATA {
+        GRAPH ${rst.termToString(graph)} {
+          ${triplesSparql.join('\n')}
+        }
+      }`,
+      {
+        'mu-call-scope-id': 'http://worship-positions-graph-dispatcher/update',
+      }
+    );
 }

--- a/lib/storeToTriplestore.js
+++ b/lib/storeToTriplestore.js
@@ -126,6 +126,18 @@ export async function getData(graph) {
   return store;
 }
 
+/**
+ * Get all triples from a certain graph and also find all the graphs each
+ * triple can be found in. Each triple in the resulting store can thus appear
+ * multiple times, but with different graphs.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} graph - The graph from which to get the triples from.
+ * @returns {N3.Store} Store containing the triples in the graph and those same
+ * triples from other graphs if they also exist there.
+ */
 export async function getTriplesAndAllGraphs(graph) {
   if (!graph)
     throw new Error(
@@ -194,9 +206,7 @@ export async function insertData(store, graph) {
 
 /**
  * Deletes given data from the triplestore. Deletes from the given graph only
- * or deletes from the graph embedded in the quad. Due to a bug in Virtuoso,
- * this function deletes typed literals one by one in separate queries as a
- * workaround.
+ * or deletes from the graph embedded in the quad.
  *
  * @async
  * @function
@@ -243,6 +253,21 @@ export async function deleteData(store, graph) {
     }
 }
 
+/**
+ * Deletes an N3 Store from the triplestore. Due to a bug in Virtuoso, this
+ * function deletes typed literals one by one in separate queries as a
+ * workaround.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} graph - Target graph where the triples should be deleted
+ * from.
+ * @param {N3.Store|Iterable} store - Store or other iterable collection
+ * containing the data that needs to be removed.
+ * @returns {undefined} Nothing. (Might return the response object of a REST
+ * call to the triplestore to remove the data.)
+ */
 async function deleteTriplesFromGraphWithoutBatching(graph, store) {
   if (store.size && store.size <= 0) return;
   if (store.length && store.length <= 0) return;


### PR DESCRIPTION
When ingesting large amounts of data, the amount of deletes became too large and the service failed.

There is a mechanism that gets the graphs for all the triples and it sends the triple with it. This is done without batching, and when the dataset becomes too large, the query becomes too big too. This is fixed by getting the graphs in a more clever way (at least when bulk processing the deletes) and further improved by batching the deletes.